### PR TITLE
Overhaul de la section #plan : UI/UX, responsive, a11y, perf, SEO, code quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Bundle statique **prêt à déployer** (GitHub Pages / Netlify / Vercel static).
 
 ## Contenu
 - `index.html` — page unique (Leaflet + cartes d’itinéraires + mini-graphiques + CTA)
-- `assets/brand.css` — styles (branding CarPostal moderne)
+- `assets/brand.css` — styles globaux
+- `assets/plan.css` — styles spécifiques à la section plan
+- `assets/plan.js` — script de la section plan (chargé en différé)
 - `data/routes.json` — données simulées (6 liaisons, temps voiture/TP/navette, coordonnées)
 - `images/` — photos locales optimisées
 - `icons/` — favicon (PNG + ICO)
@@ -20,6 +22,17 @@ Bundle statique **prêt à déployer** (GitHub Pages / Netlify / Vercel static).
 ```bash
 python3 -m http.server 4000
 # http://localhost:4000
+```
+
+## Développement
+
+```bash
+npm install
+npm run dev    # lance Vite
+npm test       # vérifie les ancres internes
+npm run build  # minifie le script plan
+npm run audit  # audit Lighthouse (nécessite Chrome)
+npm run check:accessibility # audit axe-core
 ```
 
 — Powered by MobilityLab · Opéré par CarPostal (démo)

--- a/assets/brand.css
+++ b/assets/brand.css
@@ -23,7 +23,6 @@ header{position:sticky;top:0;z-index:10;background:#0b0d10f0;backdrop-filter:blu
 .panel h3{margin:0 0 8px;font-size:1.05rem}
 .panel ul{margin:0;padding-left:18px}
 .panel li{color:#cbd5e5;margin:6px 0}
-main{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:14px;margin-top:14px}
 .card{position:relative;background:#111419;border:1px solid #1b2230;border-radius:14px;overflow:hidden;transition:.25s transform,.25s border-color}
 .card:hover{transform:translateY(-4px);border-color:#2a3340}
 .image{height:190px;background:#0f141a}

--- a/assets/plan.css
+++ b/assets/plan.css
@@ -1,0 +1,85 @@
+:root {
+  --space-s: 8px;
+  --space-m: 16px;
+  --space-l: 24px;
+}
+
+/* Skip link for keyboard navigation */
+.skip-link {
+  position: absolute;
+  left: 0;
+  top: -40px;
+  padding: var(--space-s) var(--space-m);
+  background: var(--brand);
+  color: #000;
+  font-weight: 600;
+  border-radius: 0 0 6px 0;
+  z-index: 1000;
+  transition: transform 0.2s;
+  transform: translateY(-100%);
+}
+.skip-link:focus {
+  top: 0;
+  transform: translateY(0);
+}
+
+.plan-toc {
+  position: sticky;
+  top: 72px;
+  background: var(--panel);
+  border: 1px solid var(--ring);
+  border-radius: 12px;
+  margin-bottom: var(--space-l);
+  padding: var(--space-m);
+}
+.plan-toc ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: var(--space-m);
+  flex-wrap: wrap;
+}
+.plan-toc a {
+  display: flex;
+  align-items: center;
+  gap: var(--space-s);
+  color: var(--text);
+  font-size: clamp(0.9rem, 2vw, 1rem);
+  font-weight: 600;
+}
+.plan-toc a:hover,
+.plan-toc a:focus {
+  text-decoration: underline;
+}
+.step {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent);
+  color: #05250f;
+  border-radius: 50%;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+#cards.routes {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 14px;
+  margin-top: 14px;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f2f2f2;
+    --text: #111;
+    --panel: #fff;
+    --ring: #d0d0d0;
+  }
+  .skip-link {
+    color: #111;
+  }
+}

--- a/assets/plan.js
+++ b/assets/plan.js
@@ -1,0 +1,60 @@
+const grid = document.getElementById('cards');
+const map = L.map('map').setView([46.8182, 8.2275], 8);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '© OpenStreetMap'
+}).addTo(map);
+let layers = [];
+function clearMap() {
+  layers.forEach(l => map.removeLayer(l));
+  layers = [];
+}
+
+function bars(times) {
+  const max = Math.max(times.car, times.pt, times.shuttle) || 1;
+  const H = 64;
+  const s = v => Math.max(8, Math.round(v / max * H));
+  return { car: s(times.car), tp: s(times.pt), sh: s(times.shuttle) };
+}
+
+function card(r) {
+  const h = bars(r.times);
+  const gain = r.times.pt - r.times.shuttle;
+  const rec = gain >= 30;
+  const el = document.createElement('article');
+  el.className = 'card';
+  el.innerHTML = `
+    <div class="image"><img src="${r.image}" alt="${r.to}" loading="lazy" width="640" height="360"></div>
+    <div class="badge ${rec ? '' : 'warn'}">${rec ? ('+' + gain + ' min gagnées') : 'Gain limité'}</div>
+    <div class="content">
+      <h3 class="route">${r.from} → ${r.to}</h3>
+      <div class="details">🚗 ${r.times.car} min · 🚌 TP ${r.times.pt} min · 🟢 Navette ${r.times.shuttle} min</div>
+      <div class="mini">
+        <div class="bar car" style="height:${h.car}px">V</div>
+        <div class="bar tp"  style="height:${h.tp}px">TP</div>
+        <div class="bar sh"  style="height:${h.sh}px">Nav</div>
+      </div>
+      <div class="cta">
+        <a class="btn primary" href="#map" data-map>Voir sur la carte</a>
+      </div>
+    </div>`;
+  el.querySelector('[data-map]').addEventListener('click', () => {
+    clearMap();
+    const a = [r.from_coords.lat, r.from_coords.lon];
+    const b = [r.to_coords.lat, r.to_coords.lon];
+    const m1 = L.marker(a).addTo(map).bindPopup(r.from);
+    const m2 = L.marker(b).addTo(map).bindPopup(r.to);
+    const line = L.polyline([a, b], { color: '#1DB954' }).addTo(map);
+    layers.push(m1, m2, line);
+    map.fitBounds(L.latLngBounds([a, b]).pad(0.2));
+  });
+  return el;
+}
+
+fetch('data/routes.json')
+  .then(r => r.json())
+  .then(list => {
+    list.forEach(r => grid.appendChild(card(r)));
+  })
+  .catch(e => {
+    grid.innerHTML = '<div class="panel">Erreur de chargement des données : ' + e + '</div>';
+  });

--- a/index.html
+++ b/index.html
@@ -9,15 +9,19 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css">
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <link rel="stylesheet" href="assets/brand.css">
+<link rel="stylesheet" href="assets/plan.css">
 </head>
 <body>
+<a class="skip-link" href="#plan">Passer au contenu</a>
 <header>
   <div class="head">
     <div class="logo">P</div>
     <div class="brand">PostBus Connect</div>
     <div style="margin-left:auto">Powered by <b>MobilityLab</b> — Opéré par <b>CarPostal</b></div>
   </div>
-</header>
+ </header>
+
+<main id="main-content">
 
 <section class="hero">
   <div class="hero-in">
@@ -33,7 +37,7 @@
 <div class="wrap" id="why">
   <div class="grid-3">
     <div class="panel">
-      <h3>✨ Avantages clés</h3>
+      <h2>✨ Avantages clés</h2>
       <ul>
         <li>⏱ <b>+40–80 min</b> gagnées vs. TP</li>
         <li>🧩 <b>0 correspondance</b> — monte & détends‑toi</li>
@@ -42,7 +46,7 @@
       </ul>
     </div>
     <div class="panel">
-      <h3>⚙️ Comment ça marche</h3>
+      <h2>⚙️ Comment ça marche</h2>
       <ul>
         <li>1. Choisis <b>départ</b> & <b>destination</b></li>
         <li>2. Si TP trop lents ➜ <b>navette directe</b></li>
@@ -50,7 +54,7 @@
       </ul>
     </div>
     <div class="panel">
-      <h3>🚗 Pourquoi pas la voiture / TP ?</h3>
+      <h2>🚗 Pourquoi pas la voiture / TP ?</h2>
       <ul>
         <li>Voiture : bouchons, parkings chers, stress</li>
         <li>TP : 2–3 correspondances, marche, lenteur</li>
@@ -60,57 +64,24 @@
   </div>
 </div>
 
-<div class="wrap" id="plan">
-  <div class="panel">
-    <h3>🧭 Itinéraires disponibles (simulation)</h3>
+<section class="wrap" id="plan">
+  <nav class="plan-toc" aria-label="Plan du projet">
+    <ul>
+      <li><a href="#routes"><span class="step">1</span> Itinéraires</a></li>
+      <li><a href="#map"><span class="step">2</span> Carte</a></li>
+    </ul>
+  </nav>
+  <div class="panel" id="routes">
+    <h2>🧭 Itinéraires disponibles (simulation)</h2>
     <p class="subtitle">Clique sur « Voir sur la carte » pour afficher le tracé.</p>
   </div>
-  <main id="cards"></main>
+  <div id="cards" class="routes"></div>
   <div id="map" role="img" aria-label="Carte des itinéraires"></div>
   <footer>© 2025 PostBus Connect — <b>Powered by MobilityLab</b> — Données & exploitation : CarPostal — Démo.</footer>
-</div>
+</section>
 
-<script>
-const grid = document.getElementById('cards');
-const map = L.map('map').setView([46.8182, 8.2275], 8);
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{attribution:'© OpenStreetMap'}).addTo(map);
-let layers=[]; function clearMap(){ layers.forEach(l=>map.removeLayer(l)); layers=[]; }
+</main>
 
-function bars(times){ const max=Math.max(times.car,times.pt,times.shuttle)||1,H=64,s=v=>Math.max(8,Math.round(v/max*H)); return {car:s(times.car),tp:s(times.pt),sh:s(times.shuttle)}; }
-
-function card(r){
-  const h=bars(r.times), gain=r.times.pt-r.times.shuttle, rec=gain>=30;
-  const el=document.createElement('article'); el.className='card';
-  el.innerHTML=`
-    <div class="image"><img src="${r.image}" alt="${r.to}"></div>
-    <div class="badge ${rec?'':'warn'}">${rec?('+'+gain+' min gagnées'):'Gain limité'}</div>
-    <div class="content">
-      <h3 class="route">${r.from} → ${r.to}</h3>
-      <div class="details">🚗 ${r.times.car} min · 🚌 TP ${r.times.pt} min · 🟢 Navette ${r.times.shuttle} min</div>
-      <div class="mini">
-        <div class="bar car" style="height:${h.car}px">V</div>
-        <div class="bar tp"  style="height:${h.tp}px">TP</div>
-        <div class="bar sh"  style="height:${h.sh}px">Nav</div>
-      </div>
-      <div class="cta">
-        <a class="btn primary" href="#map" data-map>Voir sur la carte</a>
-      </div>
-    </div>`;
-  el.querySelector('[data-map]').addEventListener('click',()=>{
-    clearMap();
-    const a=[r.from_coords.lat,r.from_coords.lon], b=[r.to_coords.lat,r.to_coords.lon];
-    const m1=L.marker(a).addTo(map).bindPopup(r.from);
-    const m2=L.marker(b).addTo(map).bindPopup(r.to);
-    const line=L.polyline([a,b],{color:'#1DB954'}).addTo(map);
-    layers.push(m1,m2,line);
-    map.fitBounds(L.latLngBounds([a,b]).pad(0.2));
-  });
-  return el;
-}
-
-fetch('data/routes.json').then(r=>r.json()).then(list=>{
-  list.forEach(r=> grid.appendChild(card(r)));
-}).catch(e=>{ grid.innerHTML='<div class="panel">Erreur de chargement des données : '+e+'</div>'; });
-</script>
+<script src="assets/plan.js" defer></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "postbusmagic",
+  "version": "1.0.0",
+  "description": "Bundle statique **prêt à déployer** (GitHub Pages / Netlify / Vercel static).",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "esbuild assets/plan.js --bundle --minify --outfile=assets/plan.min.js",
+    "test": "node scripts/check-anchors.js",
+    "audit": "lighthouse http://localhost:4173 --output=json --output-path=lighthouse.json || true",
+    "check:accessibility": "axe http://localhost:4173 || true"
+  },
+  "devDependencies": {
+    "@axe-core/cli": "^4.6.2",
+    "esbuild": "^0.20.1",
+    "lighthouse": "^11.7.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/scripts/check-anchors.js
+++ b/scripts/check-anchors.js
@@ -1,0 +1,17 @@
+import { readFileSync } from 'fs';
+
+const html = readFileSync('index.html', 'utf8');
+const anchorIds = Array.from(html.matchAll(/href="#(.*?)"/g)).map(m => m[1]);
+const ids = new Set(Array.from(html.matchAll(/id="(.*?)"/g)).map(m => m[1]));
+let broken = 0;
+for (const id of anchorIds) {
+  if (!ids.has(id)) {
+    console.error(`Missing target for #${id}`);
+    broken++;
+  }
+}
+if (broken) {
+  process.exit(1);
+} else {
+  console.log('All internal anchors have targets.');
+}


### PR DESCRIPTION
## Summary
- restructure #plan with sticky table of contents and keyboard skip link
- extract dedicated CSS/JS with lazy-loaded images and responsive grid
- add npm tooling, anchor check test and updated README

## Testing
- `npm test`
- `npm run build` *(fails: esbuild not found)*
- `npm run audit` *(fails: lighthouse not found)*
- `npm run check:accessibility` *(fails: axe not found)*

## Checklist
- [ ] Section #plan lisible et claire sur mobile, tablette, desktop.
- [ ] Scores Lighthouse: Perf ≥ 90, Accessibilité ≥ 95, Best Practices ≥ 95, SEO ≥ 90 sur la page.
- [ ] Aucun overflow horizontal ; tailles de police fluides (clamp()).
- [ ] Contraste couleur AA validé ; navigation clavier complète ; skip-link présent.
- [ ] Images optimisées et lazy ; scripts non critiques différés.
- [ ] README mis à jour ; script(s) d’audit disponibles.
- [ ] Aucune régression visuelle sur les autres sections.

### Changelog
- Introduced skip link and sticky table of contents for plan section
- Moved plan styles and behaviour into dedicated modules
- Added npm scripts for build, audit and accessibility checks


------
https://chatgpt.com/codex/tasks/task_e_68a4e025f8c4832bab5d2055319e8585